### PR TITLE
fix: commands.go: add columns in initdb

### DIFF
--- a/src/commands.go
+++ b/src/commands.go
@@ -13,7 +13,7 @@ import (
 
 func (oUser *OpenvpnUser) InitDb() {
 	// boolean fields are integer because of sqlite does not support boolean: 1 = true, 0 = false
-	_, err := oUser.Database.Exec("CREATE TABLE IF NOT EXISTS users(id integer not null primary key autoincrement, username string UNIQUE, password string, revoked integer default 0, deleted integer default 0)")
+	_, err := oUser.Database.Exec("CREATE TABLE IF NOT EXISTS users(id integer not null primary key autoincrement, username string UNIQUE, password string, secret string, revoked integer default 0, deleted integer default 0, app_configured integer default 0)")
 	checkErr(err)
 	_, err = oUser.Database.Exec("CREATE TABLE IF NOT EXISTS migrations(id integer not null primary key autoincrement, name string)")
 	checkErr(err)


### PR DESCRIPTION
Большое спасибо за инструмент.
Возникла проблема. Т.к. нет колонок secret и app_configured в таблице users, то не работает авторизация на релизах 1.0.8, 1.0.9. Возможно, имело смысл накатить миграции, но:
* я с ними не разбирался, хотя нашёл соответствующую функцию и пометку STUB
* считаю, что если БД создается пустая, то требуется изначально создавать правильную структуру.
